### PR TITLE
feat: 명함 페이지 디자인

### DIFF
--- a/app/[locale]/components/BusinessCardCode.tsx
+++ b/app/[locale]/components/BusinessCardCode.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { email, github, phone, portfolio, velog } from '@/constants/info';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { docco, dark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+
+export default function BusinessCardCode({
+  name,
+  job,
+}: {
+  name: string;
+  job: string;
+}) {
+  const { theme } = useTheme();
+  const [style, setStyle] = useState(dark);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const changeStyle = () => {
+      switch (theme) {
+        case 'light':
+          setStyle(docco);
+          break;
+        case 'dark':
+          setStyle(dark);
+          break;
+        default:
+          if (mediaQuery.matches) setStyle(dark);
+          else setStyle(docco);
+      }
+    };
+    changeStyle();
+    mediaQuery.addEventListener('change', changeStyle);
+    return () => mediaQuery.removeEventListener('change', changeStyle);
+  }, [theme]);
+
+  return (
+    <SyntaxHighlighter
+      language="json"
+      style={style}
+      showLineNumbers
+      customStyle={{
+        padding: '10px 20px 20px 20px',
+        height: '100%',
+        fontSize: 'clamp(10px, 3vw, 30px)',
+      }}
+    >
+      {`{
+    "name": "${name}",
+    "title": "${job}",
+    "contacts": {
+        "phone": "${phone}",
+        "email": "${email}",
+  },
+    "links": {
+        "github": "${github}",
+        "velog": "${velog}",
+        "portfolio": "${portfolio}"
+  }
+}`}
+    </SyntaxHighlighter>
+  );
+}

--- a/app/[locale]/components/Card.tsx
+++ b/app/[locale]/components/Card.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { ReactNode, Children, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  motion,
+  useScroll,
+  useTransform,
+  MotionValue,
+  useMotionTemplate,
+} from 'framer-motion';
+import { useSpringTransform } from '@/app/[locale]/hooks/useSpringTransform';
+
+/** 자식을 2개 받음 (first children: front, second children: back) */
+export default function Card({ children }: { children: ReactNode }) {
+  const childArray = Children.toArray(children);
+  const front = childArray[0] ?? null;
+  const back = childArray[1] ?? null;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({
+    target: containerRef,
+    offset: ['start 64px', 'end end'],
+  });
+
+  const springTransform = useSpringTransform(scrollYProgress);
+
+  const scaleX = springTransform([0, 0.3, 0.7, 1], [1, 0.7, 0.7, 1]);
+  const scaleY = springTransform([0, 0.3, 0.7, 1], [1, 0.7, 0.7, 1]);
+  const rotateX = springTransform([0.3, 0.7], [0, 180]);
+  const borderRadius = springTransform([0, 0.3, 0.7, 1], [0, 32, 32, 0]);
+  const shadowY = springTransform([0, 0.3, 0.7, 1], [0, 16, 16, 0]);
+  const blur = useTransform(shadowY, (v) => v * 1.5);
+  const spread = useTransform(shadowY, (v) => v * 0.4);
+  const boxShadow = useMotionTemplate`0px ${shadowY}px ${blur}px ${spread}px rgba(0 0 0 / 0.18)`;
+
+  return (
+    <div ref={containerRef} className="min-h-[200vh]">
+      <div className="sticky top-16 h-[calc(100dvh-64px)] flex items-center justify-center [perspective:1200px] px-4 overflow-hidden">
+        <motion.div
+          style={{
+            scaleX,
+            scaleY,
+            rotateX,
+            transformStyle: 'preserve-3d',
+            WebkitTransformStyle: 'preserve-3d',
+            willChange: 'transform',
+          }}
+          className="absolute inset-0 transform-gpu"
+        >
+          <InnerCard
+            direction="front"
+            borderRadius={borderRadius}
+            boxShadow={boxShadow}
+          >
+            {front}
+          </InnerCard>
+          <InnerCard
+            direction="back"
+            borderRadius={borderRadius}
+            boxShadow={boxShadow}
+          >
+            {back}
+          </InnerCard>
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+const InnerCard = ({
+  children,
+  borderRadius,
+  direction,
+  boxShadow,
+}: {
+  children: ReactNode;
+  borderRadius: MotionValue<number>;
+  direction: 'front' | 'back';
+  boxShadow: MotionValue<string>;
+}) => {
+  return (
+    <motion.div
+      style={{ WebkitBackfaceVisibility: 'hidden', borderRadius, boxShadow }}
+      className={cn(
+        'absolute inset-0 [backface-visibility:hidden] flex items-center justify-center overflow-hidden',
+        direction === 'back' && '[transform:rotateX(180deg)]'
+      )}
+    >
+      {children}
+    </motion.div>
+  );
+};

--- a/app/[locale]/hooks/useSpringTransform.ts
+++ b/app/[locale]/hooks/useSpringTransform.ts
@@ -1,0 +1,10 @@
+import { useSpring, useTransform, MotionValue } from 'framer-motion';
+
+export const useSpringTransform = (motionValue: MotionValue) => {
+  return (inputRange: number[], outputRange: number[]) =>
+    useSpring(useTransform(motionValue, inputRange, outputRange), {
+      stiffness: 200,
+      damping: 20,
+      mass: 0.5,
+    });
+};

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -39,7 +39,7 @@ export default async function LocaleLayout({ children, params }: Props) {
             enableSystem
             disableTransitionOnChange
           >
-            <Navigation />
+            <Navigation isFixedTop />
             {children}
             <Footer />
           </ThemeProvider>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,8 +1,20 @@
+import { ReactNode } from 'react';
 import { Locale, useTranslations } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
+import Card from './components/Card';
+import {
+  Mail,
+  Smartphone,
+  Settings,
+  MapPin,
+  Github,
+  Archive,
+} from 'lucide-react';
+import { phone, email } from '@/constants/info';
+import BusinessCardCode from './components/BusinessCardCode';
 
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
   params: Promise<{ locale: Locale }>;
 };
 
@@ -17,5 +29,64 @@ export async function generateMetadata(props: Omit<Props, 'children'>) {
 
 export default function Home() {
   const t = useTranslations('Home');
-  return <div>{t('title')}</div>;
+  const name = t('name');
+  const job = t('job');
+  const location = t('location');
+  const github = t('github');
+  const velog = t('velog');
+
+  return (
+    <main>
+      <Card>
+        {/* 명함 앞면 */}
+        <div className="relative size-full overflow-hidden bg-slate-400 dark:bg-gray-800 outline-2 outline-white -outline-offset-[20px]">
+          <div className="absolute top-1/12 right-1/2 md:right-1/12 flex flex-col justify-center gap-4 max-md:translate-x-1/2">
+            <div className="text-3xl xs:text-5xl lg:text-7xl text-nowrap">
+              {name}
+            </div>
+          </div>
+
+          <div className="absolute top-3/5 left-1/2 -translate-x-1/2 -translate-y-1/2 text-nowrap flex flex-col md:flex-row items-center justify-center w-full max-md:gap-10">
+            <div className="text-xl xs:text-2xl sm:text-3xl lg:text-4xl flex-1 justify-center flex max-md:border-t-2 max-md:pt-10">
+              {job}
+            </div>
+            {/* TODO: 버튼 액션을 주려면 버튼 부분을 클라이언트 컴포넌트로 빼내야함. 또한 SSR 에 icon 및 text 부분을 적용하려면 서버컴포넌트에 남겨야함. */}
+            <div className="flex flex-col justify-center gap-4 flex-1 md:border-l-2 max-md:border-t-2 max-md:pt-10">
+              {[
+                { icon: <MapPin size={18} />, text: location },
+                { icon: <Smartphone size={18} />, text: phone },
+                { icon: <Mail size={18} />, text: email },
+                { icon: <Github size={18} />, text: github },
+                { icon: <Archive size={18} />, text: velog },
+              ].map(({ icon, text }) => (
+                <div className="flex items-center gap-2 md:pl-20" key={text}>
+                  {icon}
+                  <span className="text-xs xs:text-sm sm:text-base">
+                    {text}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* 명함 뒷면 */}
+        <div className="relative w-full h-full bg-stone-200 dark:bg-stone-900">
+          <div className="p-4 flex items-center justify-between h-12 gap-1">
+            <div className="flex gap-2">
+              <div className="size-4 rounded-full bg-red-400" />
+              <div className="size-4 rounded-full bg-yellow-400" />
+              <div className="size-4 rounded-full bg-green-400" />
+            </div>
+            <div className="text-nowrap truncate">Business Card.json</div>
+            <div>
+              <Settings />
+            </div>
+          </div>
+          <BusinessCardCode name={name} job={job} />
+        </div>
+      </Card>
+      <div className="h-[200vh] bg-red-500"> 하단 요소</div>
+    </main>
+  );
 }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -57,7 +57,9 @@ export default function Navigation({
         )}
       >
         <div className="max-w-5xl justify-between flex-1 flex items-center">
-          <Link href="/">{commonT('service-name')}</Link>
+          <Link href="/" className="break-keep">
+            {commonT('service-name')}
+          </Link>
           <div
             className={cn(
               'max-lg:bg-background max-lg:px-4 max-lg:transition-all max-lg:w-screen max-lg:duration-300 max-lg:block max-lg:h-0 max-lg:overflow-hidden max-lg:absolute max-lg:top-16 max-lg:left-0 max-lg:z-10',

--- a/constants/info.ts
+++ b/constants/info.ts
@@ -1,0 +1,5 @@
+export const phone = '0507-1312-4883';
+export const email = 'yp071704@gmail.com';
+export const github = 'https://github.com/yponion'
+export const velog = 'https://velog.io/@yp071704'
+export const portfolio = 'https://yju-portfolio.com'

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
   "Common": {
-    "service-name": "next-intl-template"
+    "service-name": "YJU's Portfolio"
   },
   "NotFound": {
     "title": "Page Not Found",
@@ -27,13 +27,18 @@
     "test": "Test"
   },
   "Home": {
-    "title": "home page"
+    "title": "YJU's Portfolio",
+    "name": "Jeongun Yang",
+    "job": "Frontend Developer",
+    "location": "Seoul",
+    "github": "Github",
+    "velog": "velog"
   },
   "Test": {
     "title": "test page"
   },
   "Footer": {
-    "copyright": "© {year} Yang jeong un. All rights reserved.",
+    "copyright": "© {year} Jeongun Yang. All rights reserved.",
     "sitemap": "Sitemap"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,6 +1,6 @@
 {
   "Common": {
-    "service-name": "넥스트-국제화-템플릿"
+    "service-name": "양정운 포트폴리오"
   },
   "NotFound": {
     "title": "페이지를 찾을 수 없음",
@@ -27,13 +27,18 @@
     "test": "테스트"
   },
   "Home": {
-    "title": "홈 페이지"
+    "title": "양정운 포트폴리오",
+    "name": "양정운",
+    "job": "프론트엔드 개발자",
+    "location": "서울특별시",
+    "github": "깃허브",
+    "velog": "벨로그"
   },
   "Test": {
     "title": "테스트 페이지"
   },
   "Footer": {
-    "copyright": "© {year} Yang jeong un. 모든 권리 보유.",
+    "copyright": "© {year} 양정운. 모든 권리 보유.",
     "sitemap": "사이트맵"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.23.12",
     "lucide-react": "^0.542.0",
     "next": "15.5.0",
     "next-intl": "^4.3.5",
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-syntax-highlighter": "^16.0.0",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
@@ -28,6 +30,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
     "tailwindcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      framer-motion:
+        specifier: ^12.23.12
+        version: 12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       lucide-react:
         specifier: ^0.542.0
         version: 0.542.0(react@19.1.0)
@@ -41,6 +44,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-syntax-highlighter:
+        specifier: ^16.0.0
+        version: 16.0.0(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -60,6 +66,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.8(@types/react@19.1.11)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       eslint:
         specifier: ^9
         version: 9.34.0(jiti@2.5.1)
@@ -81,6 +90,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
@@ -804,6 +817,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -813,13 +829,25 @@ packages:
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
 
+  '@types/prismjs@1.26.5':
+    resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
+
   '@types/react-dom@19.1.8':
     resolution: {integrity: sha512-xG7xaBMJCpcK0RpN8jDbAACQo54ycO6h4dSSmgv8+fu6ZIAdANkx/WsawASUjVXYfy+J9AbUpRMNNEsXCDfDBQ==}
     peerDependencies:
       '@types/react': ^19.0.0
 
+  '@types/react-syntax-highlighter@15.5.13':
+    resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
+
   '@types/react@19.1.11':
     resolution: {integrity: sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.41.0':
     resolution: {integrity: sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==}
@@ -1090,6 +1118,15 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -1117,6 +1154,9 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1162,6 +1202,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1368,6 +1411,9 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fault@1.0.4:
+    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1399,6 +1445,24 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
+
+  framer-motion@12.23.12:
+    resolution: {integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1482,6 +1546,18 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  highlightjs-vue@1.0.0:
+    resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1504,6 +1580,12 @@ packages:
 
   intl-messageformat@10.7.16:
     resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1543,6 +1625,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1558,6 +1643,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -1738,6 +1826,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowlight@1.20.0:
+    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
+
   lucide-react@0.542.0:
     resolution: {integrity: sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==}
     peerDependencies:
@@ -1780,6 +1871,12 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  motion-dom@12.23.12:
+    resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1890,6 +1987,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1928,8 +2028,15 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1976,6 +2083,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-syntax-highlighter@16.0.0:
+    resolution: {integrity: sha512-xFteM6h1e6xzuHESS45eh5Nq84K2tnP9xsnzHMAuQyQjhVJFMp2CntURH4Hux/z1SyQf6cKSc2dR6LpxpetoGw==}
+    peerDependencies:
+      react: '>= 0.14.0'
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -1983,6 +2095,9 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  refractor@5.0.0:
+    resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2081,6 +2196,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -2277,6 +2395,8 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/runtime@7.28.4': {}
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -2924,6 +3044,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -2932,13 +3056,23 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prismjs@1.26.5': {}
+
   '@types/react-dom@19.1.8(@types/react@19.1.11)':
+    dependencies:
+      '@types/react': 19.1.11
+
+  '@types/react-syntax-highlighter@15.5.13':
     dependencies:
       '@types/react': 19.1.11
 
   '@types/react@19.1.11':
     dependencies:
       csstype: 3.1.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -3237,6 +3371,12 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
@@ -3264,6 +3404,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -3304,6 +3446,10 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  decode-named-character-reference@1.2.0:
+    dependencies:
+      character-entities: 2.0.2
 
   deep-is@0.1.4: {}
 
@@ -3666,6 +3812,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@1.0.4:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -3693,6 +3843,17 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  format@0.2.2: {}
+
+  framer-motion@12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.23.12
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   function-bind@1.1.2: {}
 
@@ -3780,6 +3941,22 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+
+  highlight.js@10.7.3: {}
+
+  highlightjs-vue@1.0.0: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3803,6 +3980,13 @@ snapshots:
       '@formatjs/fast-memoize': 2.2.7
       '@formatjs/icu-messageformat-parser': 2.11.2
       tslib: 2.8.1
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -3851,6 +4035,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -3867,6 +4053,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-map@2.0.3: {}
 
@@ -4026,6 +4214,11 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lowlight@1.20.0:
+    dependencies:
+      fault: 1.0.4
+      highlight.js: 10.7.3
+
   lucide-react@0.542.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -4060,6 +4253,12 @@ snapshots:
       minipass: 7.1.2
 
   mkdirp@3.0.1: {}
+
+  motion-dom@12.23.12:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
 
   ms@2.1.3: {}
 
@@ -4178,6 +4377,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -4206,11 +4415,15 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prismjs@1.30.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-information@7.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -4250,6 +4463,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.11
 
+  react-syntax-highlighter@16.0.0(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      highlight.js: 10.7.3
+      highlightjs-vue: 1.0.0
+      lowlight: 1.20.0
+      prismjs: 1.30.0
+      react: 19.1.0
+      refractor: 5.0.0
+
   react@19.1.0: {}
 
   reflect.getprototypeof@1.0.10:
@@ -4262,6 +4485,13 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  refractor@5.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/prismjs': 1.26.5
+      hastscript: 9.0.1
+      parse-entities: 4.0.2
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -4411,6 +4641,8 @@ snapshots:
     optional: true
 
   source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
 
   stable-hash@0.0.5: {}
 


### PR DESCRIPTION
### 개요

홈페이지에 접속했을 때 뜨는 메인화면의 첫번째 섹션을 명함 처럼 디자인하다.

### 상세

- framer-motion 을 이용하여 스크롤시 명함을 뒤집는 애니메이션을 구현.
- 텍스트값 이지만 언어에 따라 달라지지 않는 값들(이메일, 링크 등)을 상수로 선언.
- 화면 너비에 따른 텍스트 크기 및 배치 변경.
- Separator 색상이 light 모드와 dark 모드에서 다른 것은 의도된 것임.

  | light | dark |
  |-|-|
  |<img width="874" height="271" alt="light-스크린샷" src="https://github.com/user-attachments/assets/0202c071-fca7-4831-bd9e-ddd2f0390816" />|<img width="946" height="279" alt="dark-스크린샷" src="https://github.com/user-attachments/assets/52121998-3591-4c57-861d-92105c052ef4" />|

#### TODO

- 전화번호, 이메일 등을 클릭했을 때 버튼 액션을 주려면 버튼 부분을 클라이언트 컴포넌트로 빼내야함. 또한 SSR 에 icon 및 text 부분을 적용하려면 서버컴포넌트에 남겨야함.

### 관련 이슈

- Closes #1 
